### PR TITLE
0.0.2 Adding support to Xray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.2] - 2024-06-24
+
+- Added support to xray tracing.
+
 ## [0.0.1] - 2023-09-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enable_logs"></a> [enable\_logs](#input\_enable\_logs) | Enable CloudWatch Logs for the Lambda Function. | `bool` | `false` | no |
-| <a name="input_enable_xray"></a> [enable\_xray](#input\_enable\_xray) | Enable X-Ray tracing for the Lambda function | `bool` | `false` | no |
+| <a name="input_enable_xray"></a> [enable\_xray](#input\_enable\_xray) | Enable X-Ray tracing for the Lambda function. | `bool` | `false` | no |
 | <a name="input_extra_permissions_policy_arns"></a> [extra\_permissions\_policy\_arns](#input\_extra\_permissions\_policy\_arns) | List of policy arns you need to add the function role. Should be used for preexisting policies, not managed by this module. | `set(string)` | `[]` | no |
 | <a name="input_function_description"></a> [function\_description](#input\_function\_description) | Description of what your Lambda Function does. | `string` | n/a | yes |
 | <a name="input_function_ephemeral_storage"></a> [function\_ephemeral\_storage](#input\_function\_ephemeral\_storage) | Size of the /tmp directory in MB available to your Lambda Function. | `number` | `512` | no |
@@ -115,14 +115,14 @@ No modules.
 | <a name="input_function_memory"></a> [function\_memory](#input\_function\_memory) | Amount of memory in MB your Lambda Function can use at runtime. | `number` | `128` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | Unique name for your Lambda Function. | `string` | n/a | yes |
 | <a name="input_function_runtime"></a> [function\_runtime](#input\_function\_runtime) | An object selecting the Lambda runtime and its associated placeholder. | `string` | n/a | yes |
-| <a name="input_function_timeout_seconds"></a> [function\_timeout\_seconds](#input\_function\_timeout\_seconds) | Amount of time your Lambda Function has to run in seconds | `number` | `10` | no |
+| <a name="input_function_timeout_seconds"></a> [function\_timeout\_seconds](#input\_function\_timeout\_seconds) | Amount of time your Lambda Function has to run in seconds. | `number` | `10` | no |
 | <a name="input_lambda_environment_variables"></a> [lambda\_environment\_variables](#input\_lambda\_environment\_variables) | Values for environment variables that are accessible from function code during execution. | <pre>object({<br>    variables = map(string)<br>  })</pre> | `null` | no |
-| <a name="input_lambda_package_type"></a> [lambda\_package\_type](#input\_lambda\_package\_type) | Value for package\_type in aws\_lambda\_function resource | `string` | `"Zip"` | no |
-| <a name="input_logs_retention_days"></a> [logs\_retention\_days](#input\_logs\_retention\_days) | How many days aws should keep the logs of this function | `number` | `14` | no |
+| <a name="input_lambda_package_type"></a> [lambda\_package\_type](#input\_lambda\_package\_type) | Value for package\_type in aws\_lambda\_function resource. | `string` | `"Zip"` | no |
+| <a name="input_logs_retention_days"></a> [logs\_retention\_days](#input\_logs\_retention\_days) | How many days aws should keep the logs of this function. | `number` | `14` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the role. | `string` | `""` | no |
-| <a name="input_sqs_batch_size"></a> [sqs\_batch\_size](#input\_sqs\_batch\_size) | In case the lambda subscribes to a queue, refers to the number of messages that Lambda retrieves and processes from an SQS queue in a single invocation. This parameter allows you to control how many messages are processed in a single Lambda function execution | `number` | `1` | no |
+| <a name="input_sqs_batch_size"></a> [sqs\_batch\_size](#input\_sqs\_batch\_size) | In case the lambda subscribes to a queue, refers to the number of messages that Lambda retrieves and processes from an SQS queue in a single invocation. This parameter allows you to control how many messages are processed in a single Lambda function execution. | `number` | `1` | no |
 | <a name="input_subscribe_to_queue"></a> [subscribe\_to\_queue](#input\_subscribe\_to\_queue) | Whether the lambda will subscribe to a queue or not. | `bool` | `false` | no |
-| <a name="input_subscribing_queue_arn"></a> [subscribing\_queue\_arn](#input\_subscribing\_queue\_arn) | If the lambda subscribes to a queue, use this variable to inform the SQS object arn | `string` | `null` | no |
+| <a name="input_subscribing_queue_arn"></a> [subscribing\_queue\_arn](#input\_subscribing\_queue\_arn) | If the lambda subscribes to a queue, use this variable to inform the SQS object arn. | `string` | `null` | no |
 | <a name="input_vpc_config"></a> [vpc\_config](#input\_vpc\_config) | VPC configuration for your Lambda Function. | <pre>object({<br>    security_group_ids = list(string)<br>    subnet_ids         = list(string)<br>  })</pre> | `null` | no |
 
 ## Outputs

--- a/docs/example.tf
+++ b/docs/example.tf
@@ -1,16 +1,16 @@
 module "lambda" {
-  source = "/Users/user2/Documents/GitHub/kehe/terraform-aws-lambda"
-
+  source               = "madelabs/lambda/aws"
+  version              = "0.0.2"
   function_name        = "hello-world"
   function_description = "Hello World"
   function_handler     = "placeholder::placeholder.Function::FunctionHandler"
 
   function_runtime = "dotnet6"
-
+  enable_xray      = true
 
   vpc_config = {
-    subnet_ids         = ["subnet-0123456789abcdef0", "subnet-0123456789abcdef1"]
-    security_group_ids = ["sg-0123456789abcdef0"]
+    subnet_ids         = ["subnet-id"]
+    security_group_ids = ["sg-id"]
   }
 
   lambda_environment_variables = {
@@ -19,4 +19,5 @@ module "lambda" {
       "TESTBED"                = "true"
     }
   }
+  permissions_boundary = "Boundary role arn"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -57,6 +57,12 @@ resource "aws_iam_role_policy_attachment" "att_vpc_execution" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
+resource "aws_iam_role_policy_attachment" "att_lambda_xray" {
+  count      = var.enable_xray == true ? 1 : 0
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
+}
+
 resource "aws_iam_role_policy_attachment" "att_extra_permissions" {
   for_each   = var.extra_permissions_policy_arns
   role       = aws_iam_role.lambda_role.name

--- a/lambda.tf
+++ b/lambda.tf
@@ -27,4 +27,8 @@ resource "aws_lambda_function" "lambda" {
       subnet_ids         = vpc_config.value.subnet_ids
     }
   }
+
+  tracing_config {
+    mode = var.enable_xray ? "Active" : "PassThrough"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "permissions_boundary" {
 
 variable "subscribing_queue_arn" {
   type        = string
-  description = "If the lambda subscribes to a queue, use this variable to inform the SQS object arn"
+  description = "If the lambda subscribes to a queue, use this variable to inform the SQS object arn."
   default     = null
 }
 
@@ -43,7 +43,7 @@ variable "subscribe_to_queue" {
 
 variable "sqs_batch_size" {
   type        = number
-  description = "In case the lambda subscribes to a queue, refers to the number of messages that Lambda retrieves and processes from an SQS queue in a single invocation. This parameter allows you to control how many messages are processed in a single Lambda function execution"
+  description = "In case the lambda subscribes to a queue, refers to the number of messages that Lambda retrieves and processes from an SQS queue in a single invocation. This parameter allows you to control how many messages are processed in a single Lambda function execution."
   default     = 1
 }
 
@@ -72,13 +72,13 @@ variable "lambda_environment_variables" {
 
 variable "logs_retention_days" {
   type        = number
-  description = "How many days aws should keep the logs of this function"
+  description = "How many days aws should keep the logs of this function."
   default     = 14
 }
 
 variable "lambda_package_type" {
   type        = string
-  description = "Value for package_type in aws_lambda_function resource"
+  description = "Value for package_type in aws_lambda_function resource."
   default     = "Zip"
 }
 
@@ -96,7 +96,7 @@ variable "function_memory" {
 
 variable "function_timeout_seconds" {
   type        = number
-  description = "Amount of time your Lambda Function has to run in seconds"
+  description = "Amount of time your Lambda Function has to run in seconds."
   default     = 10
 }
 
@@ -107,7 +107,7 @@ variable "extra_permissions_policy_arns" {
 }
 
 variable "enable_xray" {
-  description = "Enable X-Ray tracing for the Lambda function"
+  description = "Enable X-Ray tracing for the Lambda function."
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,3 +105,9 @@ variable "extra_permissions_policy_arns" {
   description = "List of policy arns you need to add the function role. Should be used for preexisting policies, not managed by this module."
   default     = []
 }
+
+variable "enable_xray" {
+  description = "Enable X-Ray tracing for the Lambda function"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# Pull Request

## What does this PR do?
It adds Xray support to lambdas through the new parameter enable-xray. 

## Why is this PR being done?
Some environments require xray to be enabled on lambda functions to enforce monitoring. 

## Checklist - These are **not** mandatory

- [x] I have updated the README.md if there are new procedures or changes.
- [x] I have updated CHANGELOG.md with new changes. 
- [x] I have deployed this change in another project successfully.

## Optional: Additional Notes
